### PR TITLE
Allow capture of environment variables 

### DIFF
--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -96,3 +96,19 @@ fn test_read_from_reader_with_extra_lines() {
   .collect();
   assert_eq!(result, expected);
 }
+
+#[test]
+fn test_parse_line_as_capture() {
+  env::set_var("FOO", "bar");
+  let line = "FOO";
+  let pair = parse_line(line, false).unwrap().unwrap();
+  assert_eq!(pair, Pair("FOO".to_string(), "bar".to_string()));
+}
+
+#[test]
+fn test_parse_line() {
+  env::set_var("FOO", "bar");
+  let line = "FOO=notbar";
+  let pair = parse_line(line, false).unwrap().unwrap();
+  assert_eq!(pair, Pair("FOO".to_string(), "notbar".to_string()));
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,7 +27,7 @@ pub struct GetAWSParametersOptions {
   pub acc: Vec<Parameter>,
   pub client: Client,
 }
-
+#[derive(Debug, PartialEq)]
 pub struct Pair(pub String, pub String);
 
 impl From<(String, String)> for Pair {


### PR DESCRIPTION
Instead of:
```
export FOO=1
provide -e FOO=$FOO --raw
 => FOO=1
```
or
```
provide -e BAR --raw    
=> BadFormat: Invalid key=value pair BAR
```

Capture environment variables using
```
 FOO=1 provide -e FOO --raw
 => FOO=1
```
However, the variable _must_ exist or an error will be thrown.

This feature is the same as the way `docker` cli behaves.
