### PR TITLE
Do not force uppercase keys in output

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -172,8 +172,7 @@ fn extract_key_from_path(param_path: &str) -> Result<String, Error> {
 pub fn as_env_format(map: HashMap<String, String>, raw: bool) -> String {
   let lines: Vec<String> = map
     .into_iter()
-    .map(|(k, v)| {
-      let key = k.to_uppercase();
+    .map(|(key, v)| {
       let val = if raw { v } else { base64::encode(&v) };
       format!("{key}={val}\n")
     })
@@ -184,8 +183,7 @@ pub fn as_env_format(map: HashMap<String, String>, raw: bool) -> String {
 pub fn as_export_format(map: HashMap<String, String>, raw: bool) -> String {
   let lines: Vec<String> = map
     .into_iter()
-    .map(|(k, v)| {
-      let key = k.to_uppercase();
+    .map(|(key, v)| {
       if raw {
         let val = base64::encode(&v);
         format!("export {key}={val}\n")

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -43,8 +43,8 @@ fn test_as_env_format() {
   .collect();
   let env_format = as_env_format(map, true);
   let mut result: Vec<&str> = env_format.trim().split("\n").collect();
-  result.sort();
-  assert_eq!(result, vec!["ONE=bar", "THREE=clock", "TWO=baz"]);
+  result.sort_by_key(|line| line.to_lowercase());
+  assert_eq!(result, vec!["one=bar", "THREE=clock", "two=baz"]);
 }
 
 #[test]


### PR DESCRIPTION
Presently provide forces keys to uppercase on output.
```
a=1 A=2 provide -e a --raw
=> A=1
```
This is confusing and this pr changes this behavior such that
```
a=1 A=2 provide -e a --raw
=> a=1
```

